### PR TITLE
Fix file permissions

### DIFF
--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 11 14:40:12 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.5
+  * Fix issue with file permissions during package installation in
+    /usr/share/salt-formulas (0755, root, salt)
+    (boo#1142306)
+
+-------------------------------------------------------------------
 Wed Nov  6 06:23:13 UTC 2019 - nick wang <nwang@suse.com>
 
 - Version 0.3.4

--- a/drbd-formula.spec
+++ b/drbd-formula.spec
@@ -17,10 +17,9 @@
 
 
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
-%define fname drbd
-%define fdir %{_datadir}/salt-formulas
+
 Name:           drbd-formula
-Version:        0.3.4
+Version:        0.3.5
 Release:        0
 Summary:        DRBD deployment salt formula
 License:        Apache-2.0
@@ -29,14 +28,13 @@ URL:            https://github.com/SUSE/%{name}
 Source0:        %{name}-%{version}.tar.gz
 Requires:       drbd-utils
 Requires:       salt-shaptools
+Requires:       salt-formulas-configuration
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
-# On SLE/Leap 15-SP1 and TW requires the new salt-formula configuration location.
-%if ! (0%{?sle_version:1} && 0%{?sle_version} < 150100)
-Requires:       salt-formulas-configuration
-%endif
-
+%define fname drbd
+%define fdir %{_datadir}/salt-formulas
+%define ftemplates templates
 
 %description
 DRBD deployment salt formula
@@ -48,44 +46,28 @@ Available on SUSE manager 4.0
 %build
 
 %install
-# before SUMA 4.0/15-SP1, install on the standard Salt Location.
-%if 0%{?sle_version:1} && 0%{?sle_version} < 150100
-mkdir -p %{buildroot}/srv/salt/
-cp -R %{fname} %{buildroot}/srv/salt
-cp -R examples %{buildroot}/srv/salt/%{fname}/templates/
-%else
-# On SUMA 4.0/15-SP1, a single shared directory will be used.
+
 mkdir -p %{buildroot}%{fdir}/states/%{fname}
 mkdir -p %{buildroot}%{fdir}/metadata/%{fname}
 cp -R %{fname} %{buildroot}%{fdir}/states
-cp -R examples %{buildroot}%{fdir}/states/%{fname}/templates/
+cp -R examples %{buildroot}%{fdir}/states/%{fname}/%{ftemplates}/
 cp -R form.yml metadata.yml pillar.example README.md %{buildroot}%{fdir}/metadata/%{fname}
-%endif
 
-%if 0%{?sle_version:1} && 0%{?sle_version} < 150100
 %files
-# %license macro is not available on older releases
-%if 0%{?sle_version} <= 120300
+%defattr(-,root,root,-)
+%if 0%{?sle_version} < 120300
 %doc README.md LICENSE
 %else
 %doc README.md
 %license LICENSE
 %endif
-/srv/salt/%{fname}
-%dir %attr(0755, root, salt) /srv/salt
-%else
-%files
-%defattr(-,root,root,-)
-%doc README.md
-%license LICENSE
-%dir %{fdir}
-%dir %{fdir}/states
-%dir %{fdir}/metadata
-%{fdir}/states/%{fname}
-%{fdir}/metadata/%{fname}
-%dir %attr(-, root, root) %{fdir}
-%dir %attr(-, root, root) %{fdir}/states
-%dir %attr(-, root, root) %{fdir}/metadata
-%endif
+
+%dir %attr(0755, root, salt) %{fdir}
+%dir %attr(0755, root, salt) %{fdir}/states
+%dir %attr(0755, root, salt) %{fdir}/metadata
+
+%attr(0755, root, salt) %{fdir}/states/%{fname}
+%attr(0755, root, salt) %{fdir}/states/%{fname}/%{ftemplates}
+%attr(0755, root, salt) %{fdir}/metadata/%{fname}
 
 %changelog


### PR DESCRIPTION
In order to use `salt-formulas-configuration` package properly with SUMA, we need to change the files to (0755, salt, root).

From this moment on, the files will be installed in /usr/share/salt-formulas in SLE12 and SLE15