### PR TITLE
Hotfix/add pkg retries

### DIFF
--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,8 +1,14 @@
 -------------------------------------------------------------------
+Wed Nov 13 11:59:38 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.7
+  * Retry the packages installation to make the code more robust
+
+-------------------------------------------------------------------
 Wed Nov 13 09:31:49 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.6
-  * Remove additional_repos salt state 
+  * Remove additional_repos salt state
 
 -------------------------------------------------------------------
 Mon Nov 11 14:40:12 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>

--- a/drbd-formula.spec
+++ b/drbd-formula.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           drbd-formula
-Version:        0.3.6
+Version:        0.3.7
 Release:        0
 Summary:        DRBD deployment salt formula
 License:        Apache-2.0

--- a/drbd/nfs_ready.sls
+++ b/drbd/nfs_ready.sls
@@ -2,7 +2,6 @@
 {% set host = grains['host'] %}
 
 include:
-  - drbd.additional_repos
   - drbd.mkfs
 
 {% if drbd.with_ha is sameas false %}

--- a/drbd/packages.sls
+++ b/drbd/packages.sls
@@ -12,6 +12,9 @@ install-ha-ha_sles-pattern-for-drbd:
     - fromrepo: {{ repo }}
     - pkgs:
       - patterns-ha-ha_sles
+    - retry:
+        attempts: 3
+        interval: 15
 
 {% else %}
 
@@ -22,6 +25,9 @@ install_drbd_packages:
       - drbd
       - drbd-utils
       - yast2-drbd
+    - retry:
+        attempts: 3
+        interval: 15
 
 {% if drbd.with_ha is sameas true %}
 install_cluster_packages_for_drbd:
@@ -32,6 +38,9 @@ install_cluster_packages_for_drbd:
       - hawk2
       - pacemaker
       - corosync
+    - retry:
+        attempts: 3
+        interval: 15
 
 {% else %}
 
@@ -39,6 +48,9 @@ install_nfs_packages_for_drbd:
   pkg.installed:
     - pkgs:
       - nfs-formula
+    - retry:
+        attempts: 3
+        interval: 15
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
The packages installation fails time to time, so the retries add robustness.
Besides that, the package `nfs-kernel-server` was not being installed together with the pattern making the cluster installation fail. I don't know if this is the best place to install this package.
