### PR TITLE
Add retry to more pkg.installed states

### DIFF
--- a/drbd/initial_sync.sls
+++ b/drbd/initial_sync.sls
@@ -31,6 +31,9 @@ init_drbd_install_xfs:
   pkg.installed:
     - pkgs:
       - xfsprogs
+    - retry:
+        attempts: 3
+        interval: 15
 {% endif %}
 {% endif %}
 

--- a/drbd/mkfs.sls
+++ b/drbd/mkfs.sls
@@ -11,6 +11,9 @@ drbd_install_xfs:
   pkg.installed:
     - pkgs:
       - xfsprogs
+    - retry:
+        attempts: 3
+        interval: 15
 {% endif %}
 
 drbd_format_{{ res.name }}:

--- a/drbd/nfs_ready.sls
+++ b/drbd/nfs_ready.sls
@@ -9,6 +9,9 @@ install_nfs_formula_packages_for_drbd:
   pkg.installed:
     - pkgs:
       - nfs-formula
+    - retry:
+        attempts: 3
+        interval: 15
 {% endif %}
 
 {% for res in drbd.resource %}


### PR DESCRIPTION
Hi @nick-wang ,
I have found more `pkg.installed` states that might cause issues (I have had already issues with that).
To improve that.
PD: I have not upgraded the package version and changes because this change is totally the same with the last PR