### PR TITLE
Add json rendering to jinja templates

### DIFF
--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 28 10:01:29 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.8
+  * Add json rendering to jinja templates for old salt versions 
+
+-------------------------------------------------------------------
 Wed Nov 13 11:59:38 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.7

--- a/drbd-formula.spec
+++ b/drbd-formula.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           drbd-formula
-Version:        0.3.7
+Version:        0.3.8
 Release:        0
 Summary:        DRBD deployment salt formula
 License:        Apache-2.0

--- a/drbd/global_confs.sls
+++ b/drbd/global_confs.sls
@@ -8,7 +8,7 @@
     - mode: 644
     - template: jinja
     - defaults:
-        resource: {{ drbd.resource }}
+        resource: {{ drbd.resource|json }}
 
 
 /etc/drbd.d/global_common.conf:

--- a/drbd/res.sls
+++ b/drbd/res.sls
@@ -39,6 +39,6 @@
 
 {% if res.nodes is defined and res.nodes|length > 0 %}
     - context:
-        nodes: {{ res.nodes }}
+        nodes: {{ res.nodes|json }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
I have found a bug in the formula if SLE12SP4 is used, as it uses older salt version (still in py2 i think). 
The jinja templates are not correctly rendered as it adds this `u` before the items in the dictionary.
To fix that we need to add `json` option.

More info:
https://stackoverflow.com/questions/54988262/saltstack-and-strange-unicode-quoting-from-pillar

The error:

```
/etc/drbd.conf:
  file.managed:
    - source: salt://drbd/templates/drbd.conf.j2
    - user: root
    - group: root
    - mode: 644
    - template: jinja
    - defaults:
        resource: [{u'name': u'sapdata', u'device': u'/dev/drbd1', u'disk': u'/dev/vdb1', u'file_system': u'xfs', u'mount_point': u'/mnt/sapdata/HA1', u'virtual_ip': u'192.168.134.201', u'nodes': [{u'name': u'libvirt-sles12sp4-false-po-drbd01', u'ip': u'192.168.134.30', u'port': 7990, u'id': 1}, {u'name': u'libvirt-sles12sp4-false-po-drbd02', u'ip': u'192.168.134.31', u'port': 7990, u'id': 2}]}]
```

Corrected with `json`:
```/etc/drbd.conf:
  file.managed:
    - source: salt://drbd/templates/drbd.conf.j2
    - user: root
    - group: root
    - mode: 644
    - template: jinja
    - defaults:
        resource: [{"device": "/dev/drbd1", "disk": "/dev/vdb1", "file_system": "xfs", "mount_point": "/mnt/sapdata/HA1", "name": "sapdata", "nodes": [{"id": 1, "ip": "192.168.134.30", "name": "libvirt-sles12sp4-false-po-drbd01", "port": 7990}, {"id": 2, "ip": "192.168.134.31", "name": "libvirt-sles12sp4-false-po-drbd02", "port": 7990}], "virtual_ip": "192.168.134.201"}]
```