### PR TITLE
Workaround of mkfs together with initial sync take longer time

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ drbd-formula
 [![Travis Build](https://api.travis-ci.org/SUSE/drbd-formula.svg?branch=master)](https://travis-ci.org/SUSE/drbd-formula)
 
 # Version
-0.3.3
+0.3.9
 
 # DRBD bootstrap salt formula
 

--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 18 10:39:28 UTC 2019 - nick wang <nwang@suse.com>
+
+- Version 0.3.9
+  * Make file system after initial resync finished
+  * Sleep longer in case sync source change state late
+
+-------------------------------------------------------------------
 Thu Nov 28 10:01:29 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.8

--- a/drbd-formula.spec
+++ b/drbd-formula.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           drbd-formula
-Version:        0.3.8
+Version:        0.3.9
 Release:        0
 Summary:        DRBD deployment salt formula
 License:        Apache-2.0

--- a/drbd/defaults.yaml
+++ b/drbd/defaults.yaml
@@ -6,7 +6,7 @@ drbd:
   res_template: "res_single_vol_v9.j2"
   need_init_sync: true
   sync_interval: 10
-  sync_timeout: 500
+  sync_timeout: 2000
   need_format: true
   stop_after_init_sync: true
 

--- a/drbd/initial_sync.sls
+++ b/drbd/initial_sync.sls
@@ -35,8 +35,9 @@ init-start-{{ res.name }}:
 {% endfor %}
 
 init-sleep-drbd-start:
-  cmd.run:
-    - name: 'sleep 3'
+  module.run:
+    - test.sleep:
+      - length: 3
 
 {% for res in drbd.resource %}
 {% if drbd.promotion == host %}
@@ -49,8 +50,9 @@ init-promote-{{ res.name }}:
 
 {% else %}
 init-sleep-{{ res.name }}-promote:
-  cmd.run:
-    - name: 'sleep 3'
+  module.run:
+    - test.sleep:
+      - length: 3
     - require:
       - init-sleep-drbd-start
 {% endif %}
@@ -73,8 +75,9 @@ init-wait-for-{{ res.name }}-synced:
 # check disk status in wait-for-{{ res.name }}-synced
 # sleep time should at least >= drbd.sync_interval
 init-sleep-to-wait-all-synced-{{ res.name }}:
-  cmd.run:
-    - name: 'sleep {{ drbd.sync_interval + 60 }}'
+  module.run:
+    - test.sleep:
+      - length: {{ drbd.sync_interval + 60 }}
     - require:
       - init-wait-for-{{ res.name }}-synced
 
@@ -93,8 +96,9 @@ init-format-{{ res.name }}:
 # Since eventually the later steps will be blocked
 # on waiting the primary node finished format.
 init-sleep-{{ res.name }}-format:
-  cmd.run:
-    - name: 'sleep 10'
+  module.run:
+    - test.sleep:
+      - length: 10
     - require:
       - init-sleep-to-wait-all-synced-{{ res.name }}
 {% endif %}

--- a/drbd/initial_sync.sls
+++ b/drbd/initial_sync.sls
@@ -2,6 +2,20 @@
 {% set host = grains['host'] %}
 
 {% for res in drbd.resource %}
+{% if drbd.need_format is defined and drbd.need_format is sameas true%}
+{% if res.file_system == 'xfs' %}
+init_drbd_install_xfs:
+  pkg.installed:
+    - pkgs:
+      - xfsprogs
+    - retry:
+        attempts: 3
+        interval: 15
+{% endif %}
+{% endif %}
+{% endfor %}
+
+{% for res in drbd.resource %}
 init-stop-{{ res.name }}-if-run:
   drbd.stopped:
     - name: {{ res.name }}
@@ -20,45 +34,25 @@ init-start-{{ res.name }}:
       - init-create-metadata-{{ res.name }}
 {% endfor %}
 
-init-extra-sleep:
+init-sleep-drbd-start:
   cmd.run:
     - name: 'sleep 3'
 
 {% for res in drbd.resource %}
-{% if drbd.need_format is defined and drbd.need_format is sameas true%}
-{% if res.file_system == 'xfs' %}
-init_drbd_install_xfs:
-  pkg.installed:
-    - pkgs:
-      - xfsprogs
-    - retry:
-        attempts: 3
-        interval: 15
-{% endif %}
-{% endif %}
-
 {% if drbd.promotion == host %}
 init-promote-{{ res.name }}:
   drbd.promoted:
     - name: {{ res.name }}
     - force: True
     - require:
-      - init-extra-sleep
-
-{% if drbd.need_format is defined and drbd.need_format is sameas true%}
-init-format-{{ res.name }}:
-  blockdev.formatted:
-    - name: {{ res.device }}
-    - fs_type: {{ res.file_system|default("ext4") }}
-    - force: True
-{% endif %}
+      - init-sleep-drbd-start
 
 {% else %}
-init-sleep-{{ res.name }}:
+init-sleep-{{ res.name }}-promote:
   cmd.run:
     - name: 'sleep 3'
     - require:
-      - init-extra-sleep
+      - init-sleep-drbd-start
 {% endif %}
 {% endfor %}
 
@@ -70,13 +64,40 @@ init-wait-for-{{ res.name }}-synced:
     - timeout: {{ drbd.sync_timeout }}
     - require:
 {% if drbd.promotion == host %}
-{% if drbd.format_as is defined %}
-      - init-format-{{ res.name }}
-{% else %}
       - init-promote-{{ res.name }}
-{% endif %}
 {% else %}
-      - init-sleep-{{ res.name }}
+      - init-sleep-{{ res.name }}-promote
+{% endif %}
+
+# Sleep several seconds, in case one node stop before other nodes
+# check disk status in wait-for-{{ res.name }}-synced
+# sleep time should at least >= drbd.sync_interval
+init-sleep-to-wait-all-synced-{{ res.name }}:
+  cmd.run:
+    - name: 'sleep {{ drbd.sync_interval + 60 }}'
+    - require:
+      - init-wait-for-{{ res.name }}-synced
+
+{% if drbd.need_format is defined and drbd.need_format is sameas true%}
+{% if drbd.promotion == host %}
+init-format-{{ res.name }}:
+  blockdev.formatted:
+    - name: {{ res.device }}
+    - fs_type: {{ res.file_system|default("ext4") }}
+    - force: True
+    - require:
+      - init-sleep-to-wait-all-synced-{{ res.name }}
+
+{% else %}
+# Not a must to wait format(mkfs) finished.
+# Since eventually the later steps will be blocked
+# on waiting the primary node finished format.
+init-sleep-{{ res.name }}-format:
+  cmd.run:
+    - name: 'sleep 10'
+    - require:
+      - init-sleep-to-wait-all-synced-{{ res.name }}
+{% endif %}
 {% endif %}
 
 {% if drbd.stop_after_init_sync is defined and drbd.stop_after_init_sync is sameas true %}
@@ -85,27 +106,26 @@ init-demote-{{ res.name }}:
   drbd.demoted:
     - name: {{ res.name }}
     - require:
-      - init-wait-for-{{ res.name }}-synced
-{% endif %}
-
-# Sleep several seconds, in case one node stop before other nodes
-# check disk status in wait-for-{{ res.name }}-synced
-# sleep time should at least >= drbd.sync_interval
-init-sleep-to-wait-all-before-stop-{{ res.name }}:
-  cmd.run:
-    - name: 'sleep {{ drbd.sync_interval + 60 }}'
-    - require:
-{% if drbd.promotion == host %}
-      - init-demote-{{ res.name }}
+{% if drbd.need_format is defined and drbd.need_format is sameas true%}
+      - init-format-{{ res.name }}
 {% else %}
-      - init-wait-for-{{ res.name }}-synced
+      - init-sleep-to-wait-all-synced-{{ res.name }}
+{% endif %}
 {% endif %}
 
 init-stop-{{ res.name }}:
   drbd.stopped:
     - name: {{ res.name }}
     - require:
-      - init-sleep-to-wait-all-before-stop-{{ res.name }}
+{% if drbd.promotion == host %}
+      - init-demote-{{ res.name }}
+{% else %}
+{% if drbd.need_format is defined and drbd.need_format is sameas true%}
+      - init-sleep-{{ res.name }}-format
+{% else %}
+      - init-sleep-to-wait-all-synced-{{ res.name }}
+{% endif %}
+{% endif %}
 {% endif %}
 
 {% endfor %}

--- a/drbd/initial_sync.sls
+++ b/drbd/initial_sync.sls
@@ -90,10 +90,10 @@ init-demote-{{ res.name }}:
 
 # Sleep several seconds, in case one node stop before other nodes
 # check disk status in wait-for-{{ res.name }}-synced
-# sleep time should >= drbd.sync_interval
+# sleep time should at least >= drbd.sync_interval
 init-sleep-to-wait-all-before-stop-{{ res.name }}:
   cmd.run:
-    - name: 'sleep {{ drbd.sync_interval + 3 }}'
+    - name: 'sleep {{ drbd.sync_interval + 60 }}'
     - require:
 {% if drbd.promotion == host %}
       - init-demote-{{ res.name }}

--- a/drbd/packages.sls
+++ b/drbd/packages.sls
@@ -54,3 +54,15 @@ install_nfs_packages_for_drbd:
 
 {% endif %}
 {% endif %}
+
+{% for res in drbd.resource %}
+{% if res.file_system == 'xfs' %}
+install_xfs_pacage_for_drbd:
+  pkg.installed:
+    - pkgs:
+      - xfsprogs
+    - retry:
+        attempts: 3
+        interval: 15
+{% endif %}
+{% endfor %}

--- a/drbd/promote.sls
+++ b/drbd/promote.sls
@@ -15,8 +15,9 @@ pr-demote-{{ res.name }}:
 {% else %}
 # Sleep for a while in case original pri not demote yet.
 pr-sleep-{{ res.name }}:
-  cmd.run:
-    - name: 'sleep 1'
+  module.run:
+    - test.sleep:
+      - length: 3
     - require:
       - pr-start-{{ res.name }}
 

--- a/drbd/sleep.sls
+++ b/drbd/sleep.sls
@@ -1,4 +1,0 @@
-{# Could use to help both node start, may replace by status monitor #}
-extra-sleep:
-  cmd.run:
-    - name: 'sleep 3'

--- a/examples/pillar.example.drbd
+++ b/examples/pillar.example.drbd
@@ -22,7 +22,7 @@ drbd:
   #sync_interval: 10
 
   ## Optional: timeout for waiting for resource synced
-  #sync_timeout: 500
+  #sync_timeout: 2000
 
   ## Optional: format the DRBD resource after initial resync
   #need_format: true

--- a/pillar.example
+++ b/pillar.example
@@ -22,7 +22,7 @@ drbd:
   #sync_interval: 10
 
   ## Optional: timeout for waiting for resource synced
-  #sync_timeout: 500
+  #sync_timeout: 2000
 
   ## Optional: format the DRBD resource after initial resync
   #need_format: true


### PR DESCRIPTION
- Version 0.3.9
  * Make file system after initial resync finished
  * Sleep longer in case sync source change state late
     Current commit only support differ time of resync on each node less than `60-sync_interval`. By 
     default is about 50s. Will fix this in future commits.