### PR TITLE
Polish the workaround with the fix in salt module.

### DIFF
--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 23 07:58:27 UTC 2019 - nick wang <nwang@suse.com>
+
+- Version 0.3.10
+  * With the fix of salt-shaptools 0.2.9, doesn't need to
+  estimate a long time for write I/O completion.
+
+-------------------------------------------------------------------
 Wed Dec 18 10:39:28 UTC 2019 - nick wang <nwang@suse.com>
 
 - Version 0.3.9

--- a/drbd-formula.spec
+++ b/drbd-formula.spec
@@ -19,14 +19,14 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           drbd-formula
-Version:        0.3.9
+Version:        0.3.10
 Release:        0
 Summary:        DRBD deployment salt formula
 License:        Apache-2.0
 URL:            https://github.com/SUSE/%{name}
 Source0:        %{name}-%{version}.tar.gz
 Requires:       drbd-utils
-Requires:       salt-shaptools
+Requires:       salt-shaptools >= 0.2.9
 Requires:       salt-formulas-configuration
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/drbd/initial_sync.sls
+++ b/drbd/initial_sync.sls
@@ -52,7 +52,7 @@ init-promote-{{ res.name }}:
 init-sleep-{{ res.name }}-promote:
   module.run:
     - test.sleep:
-      - length: 3
+      - length: 1
     - require:
       - init-sleep-drbd-start
 {% endif %}
@@ -77,7 +77,7 @@ init-wait-for-{{ res.name }}-synced:
 init-sleep-to-wait-all-synced-{{ res.name }}:
   module.run:
     - test.sleep:
-      - length: {{ drbd.sync_interval + 60 }}
+      - length: {{ drbd.sync_interval + 5 }}
     - require:
       - init-wait-for-{{ res.name }}-synced
 


### PR DESCRIPTION
The corresponding [fix](https://github.com/SUSE/salt-shaptools/commit/dc0b1f5afebfe9a14892a64b5f1be4a675d8fa53) released in salt-shaptools-0.2.8