### PR TITLE
bsc#1179529 - Support use different backing device per node

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Version
 
-0.3.9
+0.4.1
 
 # DRBD bootstrap salt formula
 

--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">drbd-formula</param>
-    <param name="versionformat">0.4.0+git.%ct.%h</param>
+    <param name="versionformat">0.4.1+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 24 08:30:45 UTC 2021 - nick wang <nwang@suse.com>
+
+- Version bump 0.4.1
+  * Support different backing device per node
+  (bsc#1179529)
+
+-------------------------------------------------------------------
 Tue Jan 19 13:44:20 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.4.0

--- a/drbd/res.sls
+++ b/drbd/res.sls
@@ -12,7 +12,9 @@
     - defaults:
         name: '{{ res.name }}'
         device: '{{ res.device }}'
+{% if res.disk is defined %}
         disk: '{{ res.disk }}'
+{% endif %}
 
         meta_disk: '{{ res.meta_disk|default("internal") }}'
         protocol:  '{{ res.protocol|default("C") }}'

--- a/drbd/templates/res_single_vol_v9.j2
+++ b/drbd/templates/res_single_vol_v9.j2
@@ -1,7 +1,9 @@
 resource {{ name }} {
    device    {{ device }};
-   disk      {{ disk }};
    meta-disk {{ meta_disk }};
+{%- if disk is defined %}
+   disk {{ disk }};
+{%- endif %}
    net {
       protocol	{{ protocol }};
       ping-timeout {{ ping_timeout }};
@@ -27,6 +29,9 @@ resource {{ name }} {
 {% for node in nodes -%}
 {{ "   on " ~ node.name }} {
       address   {{ node.ip ~ ":" ~ node.port }};
+{%- if node.disk is defined %}
+      disk      {{ node.disk }};
+{%- endif %}
       node-id   {{ node.id }};
    }
 {% endfor -%}

--- a/pillar.example
+++ b/pillar.example
@@ -82,6 +82,7 @@ drbd:
   #    # Define the device name and minor number of a replicated block device.
   #    device: "/dev/drbd8"
   #    # Define the lower-level block device that DRBD will use for storing the actual data.
+  #    # Also support configure disk in nodes section for different device per node.
   #    disk: "/dev/vdb1"
   #    # Optional: Define where the metadata of a replicated block device resides.
   #    meta_disk: "internal"
@@ -112,6 +113,7 @@ drbd:
   #    nodes:
   #      # Node name
   #      - name: "drbd-node1"
+  #        # disk is optional if config in resource section
   #        # Node IP address
   #        ip: "192.168.10.101"
   #        # Node port
@@ -120,6 +122,7 @@ drbd:
   #        id: 1
   #      # Node name
   #      - name: "drbd-node2"
+  #        # disk is optional if config in resource section
   #        # Node IP address
   #        ip: "192.168.10.102"
   #        # Node port


### PR DESCRIPTION
DRBD have to use different backing device in GCP to support multiple google disks attached.
Use "by-id: /dev/disk/by-id/google-*" as backing device.

In GCP, it is like /dev/disk/by-id/google-<ws>-disk-drbd-<id>-part1
Need to align pillar file to use the template res_single_vol_v9.j2