### PR TITLE
Support more parameters for variable rate resync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Version
 
-0.4.2
+0.4.3
 
 # DRBD bootstrap salt formula
 

--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">drbd-formula</param>
-    <param name="versionformat">0.4.2+git.%ct.%h</param>
+    <param name="versionformat">0.4.3+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 17 05:43:52 UTC 2021 - nick wang <nwang@suse.com>
+
+- Version bump 0.4.3
+  * Support more parameters for variable rate resync
+    max_buffers, sndbuf_size, rcvbuf_size, c_delay_target, c_min_rate
+
+-------------------------------------------------------------------
 Thu Mar 11 05:04:03 UTC 2021 - nick wang <nwang@suse.com>
 
 - Version bump 0.4.2

--- a/drbd/defaults.yaml
+++ b/drbd/defaults.yaml
@@ -20,6 +20,9 @@ drbd:
       quorum: "off"
     net:
       multi_primaries: ""
+      max_buffers: ""
+      sndbuf_size: ""
+      rcvbuf_size: ""
       fencing: ""
       after_sb_0pri: ""
       after_sb_1pri: ""

--- a/drbd/defaults.yaml
+++ b/drbd/defaults.yaml
@@ -20,9 +20,9 @@ drbd:
       quorum: "off"
     net:
       multi_primaries: ""
-      max_buffers: ""
-      sndbuf_size: ""
-      rcvbuf_size: ""
+      max_buffers: "40k"
+      sndbuf_size: "5M"
+      rcvbuf_size: "5M"
       fencing: ""
       after_sb_0pri: ""
       after_sb_1pri: ""

--- a/drbd/global_confs.sls
+++ b/drbd/global_confs.sls
@@ -25,6 +25,9 @@
         quorum: "off"
         multi_primaries: "no"
         fencing: "resource-and-stonith"
+        max_buffers: 2048
+        sndbuf_size: 0
+        rcvbuf_size: 0
         after_sb_0pri: "discard-zero-changes"
         after_sb_1pri: "discard-secondary"
         after_sb_2pri: "disconnect"
@@ -39,6 +42,9 @@
         dialog_refresh: {{ drbd.global.dialog_refresh }}
         quorum: "{{ drbd.common.options.quorum }}"
         multi_primaries: "{{ drbd.common.net.multi_primaries }}"
+        max_buffers: "{{ drbd.common.net.max_buffers}}"
+        sndbuf_size: "{{ drbd.common.net.sndbuf_size}}"
+        rcvbuf_size: "{{ drbd.common.net.rcvbuf_size}}"
         fencing: "{{ drbd.common.net.fencing }}"
         after_sb_0pri: "{{ drbd.common.net.after_sb_0pri }}"
         after_sb_1pri: "{{ drbd.common.net.after_sb_1pri }}"

--- a/drbd/global_confs.sls
+++ b/drbd/global_confs.sls
@@ -42,9 +42,9 @@
         dialog_refresh: {{ drbd.global.dialog_refresh }}
         quorum: "{{ drbd.common.options.quorum }}"
         multi_primaries: "{{ drbd.common.net.multi_primaries }}"
-        max_buffers: "{{ drbd.common.net.max_buffers}}"
-        sndbuf_size: "{{ drbd.common.net.sndbuf_size}}"
-        rcvbuf_size: "{{ drbd.common.net.rcvbuf_size}}"
+        max_buffers: "{{ drbd.common.net.max_buffers }}"
+        sndbuf_size: "{{ drbd.common.net.sndbuf_size }}"
+        rcvbuf_size: "{{ drbd.common.net.rcvbuf_size }}"
         fencing: "{{ drbd.common.net.fencing }}"
         after_sb_0pri: "{{ drbd.common.net.after_sb_0pri }}"
         after_sb_1pri: "{{ drbd.common.net.after_sb_1pri }}"

--- a/drbd/res.sls
+++ b/drbd/res.sls
@@ -24,8 +24,10 @@
         fixed_rate: {{ res.fixed_rate|default(True) }}
         resync_rate: '{{ res.resync_rate|default("100M") }}'
         c_plan_ahead: {{ res.c_plan_ahead|default(20) }}
-        c_max_rate: '{{ res.c_max_rate|default("100M") }}'
+        c_delay_target: '{{ res.c_delay_target|default(1) }}'
         c_fill_target: '{{ res.c_fill_target|default("10M") }}'
+        c_max_rate: '{{ res.c_max_rate|default("100M") }}'
+        c_min_rate: '{{ res.c_min_rate|default("4M") }}'
 
         # To concate string with number, need to use join. Like
         # name: '{{ ["drbd-node", loop.index + 1]|join('') }}'

--- a/drbd/templates/global_common.j2
+++ b/drbd/templates/global_common.j2
@@ -81,6 +81,15 @@ common {
 {%- if multi_primaries %}
                 allow-two-primaries {{ multi_primaries }};
 {%- endif %}
+{%- if max_buffers %}
+                max-buffers {{ max_buffers }};
+{%- endif %}
+{%- if sndbuf_size %}
+                sndbuf-size {{ sndbuf_size }};
+{%- endif %}
+{%- if rcvbuf_size %}
+                rcvbuf-size {{ rcvbuf_size }};
+{%- endif %}
 {%- if fencing %}
                 fencing {{ fencing }};
 {%- endif %}

--- a/drbd/templates/res_single_vol_v9.j2
+++ b/drbd/templates/res_single_vol_v9.j2
@@ -15,8 +15,10 @@ resource {{ name }} {
       c-plan-ahead	0;
 {%- else %}
       c-plan-ahead	{{ c_plan_ahead }};
-      c-max-rate	{{ c_max_rate }};
+      c-delay-target	{{ c_delay_target }};
       c-fill-target	{{ c_fill_target }};
+      c-max-rate	{{ c_max_rate }};
+      c-min-rate	{{ c_min_rate }};
 {%- endif %}
    }
    connection-mesh {

--- a/form.yml
+++ b/form.yml
@@ -113,6 +113,27 @@ drbd:
            - "yes"
         $default: "no"
 
+      max_buffers:
+        $visibleIf: .fixed_rate == false
+        $name:  MAX buffers
+        $help:  Maximal number of buffer pages allocated. Max: 128k
+        $optional: true
+        $default: 2048
+
+      sndbuf_size:
+        $visibleIf: .fixed_rate == false
+        $name:  Send buffer size
+        $help:  The socket send buffer to store packets. Max: 10M
+        $optional: true
+        $default: 0
+
+      rcvbuf_size:
+        $visibleIf: .fixed_rate == false
+        $name:  Receive buffer size
+        $help:  Packets received are stored in socket buffer. Max: 10M
+        $optional: true
+        $default: 0
+
       fencing:
         $optional: true
         $type: select
@@ -254,12 +275,13 @@ drbd:
         $type: number
         $default: 20
 
-      c_max_rate:
+      c_delay_target:
         $visibleIf: .fixed_rate == false
-        $name: C max rate
-        $help: Max rate of dynamically resync rate
+        $name: C delay target
+        $help: A constant delay time
         $optional: true
-        $default: "100M"
+        $type: number
+        $default: 1
 
       c_fill_target:
         $visibleIf: .fixed_rate == false
@@ -267,6 +289,20 @@ drbd:
         $help: Fill the buffers along the data path with a defined amount of data
         $optional: true
         $default: "10M"
+
+      c_max_rate:
+        $visibleIf: .fixed_rate == false
+        $name: C max rate
+        $help: Max rate of dynamically resync rate
+        $optional: true
+        $default: "100M"
+
+      c_min_rate:
+        $visibleIf: .fixed_rate == false
+        $name: C min rate
+        $help: Throttle the resync when device is busy
+        $optional: true
+        $default: "4M"
 
 # FIXME: drbd$need_format is not working.
 # http://docserv.nue.suse.com/documents/SUSE_Manager_develop/susemanager-best-practices/single-html/

--- a/pillar.example
+++ b/pillar.example
@@ -52,6 +52,12 @@ drbd:
   #  net:
   #    # Optional: you may assign the primary role to both nodes.
   #    multi_primaries: "no"
+  #    # Optional: Maximal number of buffer pages allocated. Max: 128k
+  #    max_buffers: 2048
+  #    # Optional: The socket send buffer to store packets. Max: 10M
+  #    sndbuf_size: 0
+  #    # Optional: Packets received are stored in socket buffer. Max: 10M
+  #    rcvbuf_size: 0
   #    # Optional: preventive measures to avoid situations where both nodes are primary and disconnected(AKA split brain)
   #    fencing: "resource-and-stonith"
   #    # Optional: split brain handler when no primary
@@ -97,10 +103,14 @@ drbd:
   #    fixed_rate:  false
   #    # Optional: Dynamically control the resync speed.
   #    c_plan_ahead: 20
-  #    # Optional: Max rate of dynamically resync rate.
-  #    c_max_rate: "100M"
+  #    # Optional: A constant delay time
+  #    c_delay_target: 1
   #    # Optional: Fill the buffers along the data path with a defined amount of data.
   #    c_fill_target: "10M"
+  #    # Optional: Max rate of dynamically resync rate.
+  #    c_max_rate: "100M"
+  #    # Optional: Throttle the resync when device is busy.
+  #    c_min_rate: "4M"
 
   #    # Optional: (salt) format the disk after initialize, required when "need_format" enabled
   #    file_system: "xfs"

--- a/templates/pillar.example.drbd
+++ b/templates/pillar.example.drbd
@@ -52,6 +52,12 @@ drbd:
   #  net:
   #    # Optional: you may assign the primary role to both nodes.
   #    multi_primaries: "no"
+  #    # Optional: Maximal number of buffer pages allocated. Max: 128k
+  #    max_buffers: 2048
+  #    # Optional: The socket send buffer to store packets. Max: 10M
+  #    sndbuf_size: 0
+  #    # Optional: Packets received are stored in socket buffer. Max: 10M
+  #    rcvbuf_size: 0
   #    # Optional: preventive measures to avoid situations where both nodes are primary and disconnected(AKA split brain)
   #    fencing: "resource-and-stonith"
   #    # Optional: split brain handler when no primary
@@ -82,8 +88,10 @@ drbd:
 
       fixed_rate:  true
       c_plan_ahead: 20
-      c_max_rate: "100M"
+      c_delay_target: 10
       c_fill_target: "10M"
+      c_max_rate: "100M"
+      c_min_rate: "4M"
 
       # Salt specific
       file_system: "xfs"


### PR DESCRIPTION
Code for https://github.com/SUSE/drbd-formula/issues/24

Support max_buffers, sndbuf_size, rcvbuf_size in global_confs conf.
Support c_delay_target, c_min_rate in resource conf.
This can help to speed up the initial sync, especially help on the big size DRBD deployment.

An example with maximum value: (need to adapt based on real ENV)
...
net {
     max-buffers     128k; # Unit in PAGE_SIZE, maxmum is 128k(131072)
     sndbuf-size     10M; # Maximum is 10M
     rcvbuf-size     10M; # Maximum is 10M
}
disk {
     c-plan-ahead        20; # Unit is 100msec
     c-delay-target      10; # Unit is 100msec
     c-fill-target       1M; # Unit is sectors
     c-max-rate          2000M; # Unit is KiB/s
     c-min-rate          4M; # 0 is unlimited
}
...