### PR TITLE
add native fencing for microsoft-azure

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">drbd-formula</param>
-    <param name="versionformat">0.4.3+git.%ct.%h</param>
+    <param name="versionformat">0.4.4+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/drbd-formula.changes
+++ b/drbd-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 17 13:56:06 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.4.4
+  * add native fencing for microsoft-azure
+
+-------------------------------------------------------------------
 Mon May 17 05:43:52 UTC 2021 - nick wang <nwang@suse.com>
 
 - Version bump 0.4.3

--- a/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
+++ b/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
@@ -60,7 +60,7 @@ property $id="cib-bootstrap-options" \
     concurrent-fencing=true
 
 primitive rsc_azure_stonith_{{ res.name }}_nfs stonith:fence_azure_arm \
-    params subscriptionId={{ grains['subscription_id'] }} resourceGroup={{ grains['resource_group_name'] }} tenantId={{ grains['tenant_id'] }} login={{ grains['fence_agent_app_id'] }} passwd="{{ grains['fence_agent_client_secret'] }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
+    params subscriptionId={{ data.azure_subscription_id }} resourceGroup={{ data.azure_resource_group_name }} tenantId={{ data.azure_tenant_id }} login={{ data.azure_fence_agent_app_id }} passwd="{{ data.azure_fence_agent_client_secret }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
     op monitor interval=3600 timeout=120 \
     meta target-role=Started
 {%- endif %}

--- a/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
+++ b/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
@@ -57,7 +57,6 @@ primitive vip_{{ res.name }}_nfs IPaddr2 \
 {%- if native_fencing %}
 property $id="cib-bootstrap-options" \
     stonith-enabled="true" \
-    stonith-action="off" \
     concurrent-fencing=true
 
 primitive rsc_azure_stonith_{{ res.name }}_nfs stonith:fence_azure_arm \

--- a/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
+++ b/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
@@ -9,6 +9,8 @@
 {%- set native_fencing = data.native_fencing|default(True) %}
 {%- elif cloud_provider == "microsoft-azure" %}
 {%- set native_fencing = data.native_fencing|default(False) %}
+{%- else %}{# all other cases like openstack and libvirt #}
+{%- set native_fencing = data.native_fencing|default(False) %}
 {%- endif %}
 
 #

--- a/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
+++ b/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
@@ -2,7 +2,14 @@
 {%- set cloud_provider = grains['cloud_provider'] %}
 {%- set drbd = salt['pillar.get']('drbd', default={}, merge=True) %}
 {%- set nfsid = 1 %}
+
+{%- if cloud_provider == "amazon-web-services" %}
 {%- set native_fencing = data.native_fencing|default(True) %}
+{%- elif cloud_provider == "google-cloud-platform" %}
+{%- set native_fencing = data.native_fencing|default(True) %}
+{%- elif cloud_provider == "microsoft-azure" %}
+{%- set native_fencing = data.native_fencing|default(False) %}
+{%- endif %}
 
 #
 # defaults and production DRBD

--- a/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
+++ b/templates/habootstrap-formula/cluster_resources_nfs_cloud.j2
@@ -47,6 +47,17 @@ primitive vip_{{ res.name }}_nfs IPaddr2 \
   op monitor interval=10 timeout=20
 
 {%- if cloud_provider == "microsoft-azure" %}
+{%- if native_fencing %}
+property $id="cib-bootstrap-options" \
+    stonith-enabled="true" \
+    stonith-action="off" \
+    concurrent-fencing=true
+
+primitive rsc_azure_stonith_{{ res.name }}_nfs stonith:fence_azure_arm \
+    params subscriptionId={{ grains['subscription_id'] }} resourceGroup={{ grains['resource_group_name'] }} tenantId={{ grains['tenant_id'] }} login={{ grains['fence_agent_app_id'] }} passwd="{{ grains['fence_agent_client_secret'] }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
+    op monitor interval=3600 timeout=120 \
+    meta target-role=Started
+{%- endif %}
 primitive rsc_socat_{{ res.name }}_nfs azure-lb \
   params port={{ data.probe }} \
   op monitor timeout=20s interval=10 depth=0


### PR DESCRIPTION
This adds the needed resources to implement native fencing on azure.

It also defines for all cloud providers the same defaults to use native fencing as https://github.com/SUSE/ha-sap-terraform-deployments/.
```
# ha-sap-terraform-deployments
grep -A5 hana_cluster_fencing_mechanism */variables.tf | grep 'variable |default'
  1:openstack/variables.tf:variable "hana_cluster_fencing_mechanism" {
  4:openstack/variables.tf-  default     = "sbd"
  8:libvirt/variables.tf:variable "hana_cluster_fencing_mechanism" {
  11:libvirt/variables.tf-  default     = "sbd"
  21:gcp/variables.tf:variable "hana_cluster_fencing_mechanism" {
  24:gcp/variables.tf-  default     = "native"
  34:azure/variables.tf:variable "hana_cluster_fencing_mechanism" {
  37:azure/variables.tf-  default     = "sbd"
  47:aws/variables.tf:variable "hana_cluster_fencing_mechanism" {
  50:aws/variables.tf-  default     = "native"
```

```
# this formula
{%- if cloud_provider == "amazon-web-services" %}
{%- set native_fencing = data.native_fencing|default(True) %}
{%- elif cloud_provider == "google-cloud-platform" %}
{%- set native_fencing = data.native_fencing|default(True) %}
{%- elif cloud_provider == "microsoft-azure" %}
{%- set native_fencing = data.native_fencing|default(False) %}
{%- endif %}

```